### PR TITLE
fix:ready_settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -74,7 +74,7 @@ class BootFinishedSkill(OVOSSkill):
         # skills might be loaded by core or run standalone, we should standardize how this is checked via bus
         # perhaps ProcessStatus with skill_id ?
         services = {k: False for k in
-                    self.settings.get("ready_settings", ["skills", "speech", "audio"])}
+                    self.settings.get("ready_settings", ["skills"])}
         start = monotonic()
         while not is_ready:
             is_ready = self.check_services_ready(services)


### PR DESCRIPTION
only wait for "skills" like default config used to do

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined device readiness checks by modifying default settings, focusing only on "skills".
  
- **Bug Fixes**
	- Improved conditions under which the device is considered ready, enhancing overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->