### PR TITLE
Complete French boot status locale

### DIFF
--- a/locale/fr-fr/dialog/confirm_no_speak_ready.dialog
+++ b/locale/fr-fr/dialog/confirm_no_speak_ready.dialog
@@ -1,1 +1,1 @@
-D'accord. Je vais arreter de vous avertir lorsque le démarrage est terminé.
+D'accord. Je ne vous avertirai plus quand le démarrage sera terminé.

--- a/locale/fr-fr/dialog/confirm_ready.dialog
+++ b/locale/fr-fr/dialog/confirm_ready.dialog
@@ -1,0 +1,3 @@
+Tous les services sont démarrés et opérationnels.
+Le système a terminé de démarrer et il est prêt.
+Tout est chargé et prêt à fonctionner.

--- a/locale/fr-fr/dialog/confirm_speak_ready.dialog
+++ b/locale/fr-fr/dialog/confirm_speak_ready.dialog
@@ -1,1 +1,1 @@
-Okay. Je vais vous avertir à chaque fois que je suis prêt lorsque le démarrage est terminé.
+D'accord. Je vous avertirai quand le système sera prêt.

--- a/locale/fr-fr/dialog/deny_ready.dialog
+++ b/locale/fr-fr/dialog/deny_ready.dialog
@@ -1,0 +1,3 @@
+Le système n'est pas encore complètement prêt.
+Le démarrage est encore en cours, patientez un instant.
+Certains services finissent encore de se lancer.

--- a/locale/fr-fr/dialog/ready.dialog
+++ b/locale/fr-fr/dialog/ready.dialog
@@ -1,1 +1,1 @@
-Je suis prêt !
+Le système est prêt.

--- a/locale/fr-fr/intent/are_you_ready.intent
+++ b/locale/fr-fr/intent/are_you_ready.intent
@@ -1,9 +1,7 @@
 Est-ce que le système est prêt
-Est-ce que tu es prêt
 Est-ce qu'Open Voice OS a bien démarré
-As-tu fini de démarrer
-As-tu terminé le démarrage
-Est-ce que tout est prêt
 Est-ce que tous les services sont prêts
 Le démarrage est-il terminé
 Le système a-t-il fini de démarrer
+Est-ce que le système a fini de démarrer
+Est-ce qu'Open Voice OS est prêt

--- a/locale/fr-fr/intent/are_you_ready.intent
+++ b/locale/fr-fr/intent/are_you_ready.intent
@@ -1,0 +1,9 @@
+Est-ce que le système est prêt
+Est-ce que tu es prêt
+Est-ce qu'Open Voice OS a bien démarré
+As-tu fini de démarrer
+As-tu terminé le démarrage
+Est-ce que tout est prêt
+Est-ce que tous les services sont prêts
+Le démarrage est-il terminé
+Le système a-t-il fini de démarrer

--- a/locale/fr-fr/intent/disable_ready_notification.intent
+++ b/locale/fr-fr/intent/disable_ready_notification.intent
@@ -1,1 +1,1 @@
-(désactiver|éteindre|arreter) (le|la|les|) (son|notification|avis|sons|notifications) de (démarrage|redémarrage)
+(désactiver|éteindre|arrêter) (la|les|) (notification|notifications|alerte|alertes) de (démarrage|redémarrage)

--- a/locale/fr-fr/intent/disable_ready_notification.intent
+++ b/locale/fr-fr/intent/disable_ready_notification.intent
@@ -1,1 +1,1 @@
-(désactiver|éteindre|arrêter) (la|les|) (notification|notifications|alerte|alertes) de (démarrage|redémarrage)
+(désactive|désactiver|éteins|éteindre|arrête|arrêter) (la notification|les notifications|l'alerte|les alertes|notification|notifications|alerte|alertes) de (démarrage|redémarrage)

--- a/locale/fr-fr/intent/enable_ready_notification.intent
+++ b/locale/fr-fr/intent/enable_ready_notification.intent
@@ -1,1 +1,1 @@
-(activer|allumer|réactiver) (la|les|) (notification|notifications|alerte|alertes) de (démarrage|redémarrage)
+(active|activer|allume|allumer|réactive|réactiver) (la notification|les notifications|l'alerte|les alertes|notification|notifications|alerte|alertes) de (démarrage|redémarrage)

--- a/locale/fr-fr/intent/enable_ready_notification.intent
+++ b/locale/fr-fr/intent/enable_ready_notification.intent
@@ -1,1 +1,1 @@
-(activer|allumer|reactiver) (le|la|les|) (son|notification|avis|sons|notifications) de (démarrage|redémarrage)
+(activer|allumer|réactiver) (la|les|) (notification|notifications|alerte|alertes) de (démarrage|redémarrage)

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,8 +1,8 @@
 {
   "skill_id": "ovos-skill-boot-finished.openvoiceos",
   "source": "https://github.com/OpenVoiceOS/ovos-skill-boot-finished",
-  "name": "Skill de démarrage terminé",
-  "description": "La skill Démarrage terminé vous avertit quand OpenVoiceOS a complètement démarré et que tous les services principaux sont prêts.",
+  "name": "Démarrage terminé",
+  "description": "Vous avertit quand OpenVoiceOS a complètement démarré et que les services principaux sont prêts.",
   "examples": [
     "Est-ce que le système est prêt ?",
     "Active les notifications de démarrage.",

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,15 @@
+{
+  "skill_id": "ovos-skill-boot-finished.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-boot-finished",
+  "name": "Skill de démarrage terminé",
+  "description": "La skill Démarrage terminé vous avertit quand OpenVoiceOS a complètement démarré et que tous les services principaux sont prêts.",
+  "examples": [
+    "Est-ce que le système est prêt ?",
+    "Active les notifications de démarrage.",
+    "Désactive les notifications de démarrage."
+  ],
+  "tags": [
+    "diagnostic",
+    "information"
+  ]
+}

--- a/translations/fr-fr/dialogs.json
+++ b/translations/fr-fr/dialogs.json
@@ -1,11 +1,21 @@
 {
-    "/dialog/confirm_no_speak_ready.dialog": [
-        "D'accord. Je vais arreter de vous avertir lorsque le démarrage est terminé."
-    ],
-    "/dialog/ready.dialog": [
-        "Je suis prêt !"
-    ],
-    "/dialog/confirm_speak_ready.dialog": [
-        "Okay. Je vais vous avertir à chaque fois que je suis prêt lorsque le démarrage est terminé."
-    ]
+  "/dialog/confirm_no_speak_ready.dialog": [
+    "D'accord. Je ne vous avertirai plus quand le démarrage sera terminé."
+  ],
+  "/dialog/ready.dialog": [
+    "Le système est prêt."
+  ],
+  "/dialog/confirm_ready.dialog": [
+    "Tous les services sont démarrés et opérationnels.",
+    "Le système a terminé de démarrer et il est prêt.",
+    "Tout est chargé et prêt à fonctionner."
+  ],
+  "/dialog/confirm_speak_ready.dialog": [
+    "D'accord. Je vous avertirai quand le système sera prêt."
+  ],
+  "/dialog/deny_ready.dialog": [
+    "Le système n'est pas encore complètement prêt.",
+    "Le démarrage est encore en cours, patientez un instant.",
+    "Certains services finissent encore de se lancer."
+  ]
 }

--- a/translations/fr-fr/intents.json
+++ b/translations/fr-fr/intents.json
@@ -1,8 +1,19 @@
 {
-    "/intent/enable_ready_notification.intent": [
-        "(activer|allumer|reactiver) (le|la|les|) (son|notification|avis|sons|notifications) de (démarrage|redémarrage)"
-    ],
-    "/intent/disable_ready_notification.intent": [
-        "(désactiver|éteindre|arreter) (le|la|les|) (son|notification|avis|sons|notifications) de (démarrage|redémarrage)"
-    ]
+  "/intent/are_you_ready.intent": [
+    "Est-ce que le système est prêt",
+    "Est-ce que tu es prêt",
+    "Est-ce qu'Open Voice OS a bien démarré",
+    "As-tu fini de démarrer",
+    "As-tu terminé le démarrage",
+    "Est-ce que tout est prêt",
+    "Est-ce que tous les services sont prêts",
+    "Le démarrage est-il terminé",
+    "Le système a-t-il fini de démarrer"
+  ],
+  "/intent/enable_ready_notification.intent": [
+    "(activer|allumer|réactiver) (la|les|) (notification|notifications|alerte|alertes) de (démarrage|redémarrage)"
+  ],
+  "/intent/disable_ready_notification.intent": [
+    "(désactiver|éteindre|arrêter) (la|les|) (notification|notifications|alerte|alertes) de (démarrage|redémarrage)"
+  ]
 }

--- a/translations/fr-fr/intents.json
+++ b/translations/fr-fr/intents.json
@@ -1,19 +1,17 @@
 {
   "/intent/are_you_ready.intent": [
     "Est-ce que le système est prêt",
-    "Est-ce que tu es prêt",
     "Est-ce qu'Open Voice OS a bien démarré",
-    "As-tu fini de démarrer",
-    "As-tu terminé le démarrage",
-    "Est-ce que tout est prêt",
     "Est-ce que tous les services sont prêts",
     "Le démarrage est-il terminé",
-    "Le système a-t-il fini de démarrer"
+    "Le système a-t-il fini de démarrer",
+    "Est-ce que le système a fini de démarrer",
+    "Est-ce qu'Open Voice OS est prêt"
   ],
   "/intent/enable_ready_notification.intent": [
-    "(activer|allumer|réactiver) (la|les|) (notification|notifications|alerte|alertes) de (démarrage|redémarrage)"
+    "(active|activer|allume|allumer|réactive|réactiver) (la notification|les notifications|l'alerte|les alertes|notification|notifications|alerte|alertes) de (démarrage|redémarrage)"
   ],
   "/intent/disable_ready_notification.intent": [
-    "(désactiver|éteindre|arrêter) (la|les|) (notification|notifications|alerte|alertes) de (démarrage|redémarrage)"
+    "(désactive|désactiver|éteins|éteindre|arrête|arrêter) (la notification|les notifications|l'alerte|les alertes|notification|notifications|alerte|alertes) de (démarrage|redémarrage)"
   ]
 }


### PR DESCRIPTION
## Summary
- add the missing French boot status dialogs, readiness intent, and localized skill metadata
- refine the existing French boot notification phrasing so it sounds natural when spoken

## Validation
- verified fr-fr file coverage against locale/en-us
- validated locale/fr-fr/skill.json parses as JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Enhanced French language support with improved system startup and readiness status messages
  * Added new French translations for startup completion notifications
  * Improved French language voice command patterns for system readiness queries and controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->